### PR TITLE
[HZN-3036] Changed to proper names for 'whit' holidays

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53,10 +53,10 @@ exports.default = function (year) {
     name: locale === NORWEGIAN ? 'Kristi Himmelsprettsdag' : 'Christs Ascension Day',
     date: (0, _moment2.default)(easter).add(39, 'days').startOf('day').format(format)
   }, {
-    name: locale === NORWEGIAN ? '1. pinsedag' : 'Whitsunday',
+    name: locale === NORWEGIAN ? '1. pinsedag' : 'Whit Sunday',
     date: (0, _moment2.default)(easter).add(49, 'days').startOf('day').format(format)
   }, {
-    name: locale === NORWEGIAN ? '2. pinsedag' : 'Whitmonday',
+    name: locale === NORWEGIAN ? '2. pinsedag' : 'Whit Monday',
     date: (0, _moment2.default)(easter).add(50, 'days').startOf('day').format(format)
   }, {
     name: locale === NORWEGIAN ? 'Nyttårsdag' : 'New years day',

--- a/index.js
+++ b/index.js
@@ -16,12 +16,12 @@ const getEaster = (year) => {
   const n0 = (h + l + 7 * m + 114);
   const n = Math.floor(n0 / 31) - 1;
   const p = n0 % 31 + 1;
-  return new Date(year,n,p);
+  return new Date(year, n, p);
 }
 const NORWEGIAN = 'no';
 const ENGLISH = 'en';
 
-export default (year, options={}) => {
+export default (year, options = {}) => {
   const easter = getEaster(year);
   const locale = options.locale === ENGLISH ? ENGLISH : NORWEGIAN;
   const format = options.format === '' ? format : options.format;
@@ -47,11 +47,11 @@ export default (year, options={}) => {
       date: moment(easter).add(39, 'days').startOf('day').format(format),
     },
     {
-      name: locale === NORWEGIAN ? '1. pinsedag' : 'Whitsunday',
+      name: locale === NORWEGIAN ? '1. pinsedag' : 'Whit Sunday',
       date: moment(easter).add(49, 'days').startOf('day').format(format),
     },
     {
-      name: locale === NORWEGIAN ? '2. pinsedag' : 'Whitmonday',
+      name: locale === NORWEGIAN ? '2. pinsedag' : 'Whit Monday',
       date: moment(easter).add(50, 'days').startOf('day').format(format),
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "holidays-norway",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "holidays-norway",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
-        "moment": "^2.10.6"
+        "moment": "^2.29.4"
       },
       "devDependencies": {
         "babel-cli": "^6.26.0",
@@ -4904,9 +4904,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -12000,9 +12000,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "holidays-norway",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A small library to get norwegian holidays by any given year.",
   "main": "dist/index.js",
   "scripts": {
@@ -20,6 +20,6 @@
     "jest": "^23.6.0"
   },
   "dependencies": {
-    "moment": "^2.10.6"
+    "moment": "^2.29.4"
   }
 }


### PR DESCRIPTION
[HZN-3036]

- Bumped version of package to distinguish this rather PATCH change.
- Also upgraded `moment` to latest version.
- Code formatting.
- `horizon-db-builder` PR: https://github.cofm/avinor-ps/horizon-db-builder/pull/92

![image](https://user-images.githubusercontent.com/85486996/209136542-136efd2f-832d-4d77-a4a9-94d73ed5951f.png)


[HZN-3036]: https://avinor.atlassian.net/browse/HZN-3036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ